### PR TITLE
2pass VBR quality improvement changes

### DIFF
--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -44,6 +44,9 @@ extern "C" {
 #define FIX_VBR_BUG 1 // PR:1484 Fix 1st pass bug (bug from rebasing the branch)
 #define FIX_10BIT     1 // PR:1484 fix 1st pass for 10bit input
 #define FIX_RC_TOKEN     1 // PR:1484 fix RC token check to include double dash
+#define FIX_VBR_GF_INTERVAL   1 // fix 2nd pass min/max_gf_interval error
+#define FIX_VBR_LAST_GOP_BITS 1 // fix 2nd pass last group too big frame size error
+#define ZERO_MIN_QP_ALLOWED   1 // set default 0 min_qp_allowed as AOM to improve VBR quality
 //***************************************************************//
 #define FIX_PAD_CHROMA_AFTER_MCTF     1 // Padding chroma after altref
 #define FEATURE_NEW_DELAY             1 // Change delay some sorts of I in PicDecision

--- a/Source/API/EbDebugMacros.h
+++ b/Source/API/EbDebugMacros.h
@@ -44,7 +44,6 @@ extern "C" {
 #define FIX_VBR_BUG 1 // PR:1484 Fix 1st pass bug (bug from rebasing the branch)
 #define FIX_10BIT     1 // PR:1484 fix 1st pass for 10bit input
 #define FIX_RC_TOKEN     1 // PR:1484 fix RC token check to include double dash
-#define FIX_VBR_GF_INTERVAL   1 // fix 2nd pass min/max_gf_interval error
 #define FIX_VBR_LAST_GOP_BITS 1 // fix 2nd pass last group too big frame size error
 #define ZERO_MIN_QP_ALLOWED   1 // set default 0 min_qp_allowed as AOM to improve VBR quality
 //***************************************************************//

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1420,7 +1420,11 @@ void eb_config_ctor(EbConfig *config_ptr) {
     config_ptr->enable_tpl_la       = 1;
     config_ptr->target_bit_rate     = 7000000;
     config_ptr->max_qp_allowed      = 63;
+#if ZERO_MIN_QP_ALLOWED
+    config_ptr->min_qp_allowed      = 0;
+#else
     config_ptr->min_qp_allowed      = 10;
+#endif
 
     config_ptr->enable_adaptive_quantization              = 2;
     config_ptr->enc_mode                                  = MAX_ENC_PRESET;

--- a/Source/Lib/Encoder/ASM_AVX2/dwt_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/dwt_avx2.c
@@ -12,7 +12,7 @@
 #include "transpose_avx2.h"
 
 int eb_av1_haar_ac_sad_8x8_uint8_input_avx2(uint8_t *input, int stride, int hbd) {
-    int32_t output[64];
+    DECLARE_ALIGNED(32, int32_t, output[64]);
 
     int32_t *out_ptr = output;
     int      i;

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -574,6 +574,7 @@ void tpl_mc_flow_dispenser(
 
                         above_row = above_data + 16;
                         left_col = left_data + 16;
+                        TxSize tx_size = TX_16X16;
                         uint8_t *recon_buffer =
                             recon_picture_ptr->buffer_y + dst_basic_offset;
 

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -668,7 +668,6 @@ void tpl_mc_flow_dispenser(
 
                         above_row = above_data + 16;
                         left_col = left_data + 16;
-                        TxSize tx_size = TX_16X16;
                         uint8_t *recon_buffer =
                             recon_picture_ptr->buffer_y + dst_basic_offset;
 

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -574,7 +574,6 @@ void tpl_mc_flow_dispenser(
 
                         above_row = above_data + 16;
                         left_col = left_data + 16;
-                        TxSize tx_size = TX_16X16;
                         uint8_t *recon_buffer =
                             recon_picture_ptr->buffer_y + dst_basic_offset;
 

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -668,6 +668,7 @@ void tpl_mc_flow_dispenser(
 
                         above_row = above_data + 16;
                         left_col = left_data + 16;
+                        TxSize tx_size = TX_16X16;
                         uint8_t *recon_buffer =
                             recon_picture_ptr->buffer_y + dst_basic_offset;
 

--- a/Source/Lib/Encoder/Codec/pass2_strategy.c
+++ b/Source/Lib/Encoder/Codec/pass2_strategy.c
@@ -2318,13 +2318,8 @@ void svt_av1_init_second_pass(SequenceControlSet *scs_ptr) {
       encode_context_ptr->gf_cfg.lag_in_frames = 25;//hack scs_ptr->static_config.look_ahead_distance + 1;
       encode_context_ptr->gf_cfg.gf_min_pyr_height = scs_ptr->static_config.hierarchical_levels;
       encode_context_ptr->gf_cfg.gf_max_pyr_height = scs_ptr->static_config.hierarchical_levels;
-#if FIX_VBR_GF_INTERVAL
-      encode_context_ptr->gf_cfg.min_gf_interval   = 0;
-      encode_context_ptr->gf_cfg.max_gf_interval   = 0;
-#else
       encode_context_ptr->gf_cfg.min_gf_interval   = 1 << scs_ptr->static_config.hierarchical_levels;
       encode_context_ptr->gf_cfg.max_gf_interval   = 1 << scs_ptr->static_config.hierarchical_levels;
-#endif
       encode_context_ptr->gf_cfg.enable_auto_arf   = 1;
       encode_context_ptr->kf_cfg.sframe_dist   = 0; // not supported yet
       encode_context_ptr->kf_cfg.sframe_mode   = 0; // not supported yet


### PR DESCRIPTION
 #define FIX_VBR_LAST_GOP_BITS 1 // fix 2nd pass last group too big frame size error
 #define ZERO_MIN_QP_ALLOWED   1 // set default 0 min_qp_allowed as AOM to improve VBR quality

# Description


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [x] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [x] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
